### PR TITLE
remove updateBaseUri

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bisonai/sbt-js",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Typescript interface to control SBT from @bisonai/sbt-contracts",
   "files": [
     "dist"
@@ -26,7 +26,7 @@
     "typescript": "^4.8.3"
   },
   "dependencies": {
-    "@bisonai/sbt-contracts": "^0.4.0",
+    "@bisonai/sbt-contracts": "^0.5.0",
     "ethers": "^5.7.2"
   }
 }

--- a/src/sbt.ts
+++ b/src/sbt.ts
@@ -89,24 +89,6 @@ export class SBT {
     }
   }
 
-  public async updateBaseUri({
-    sbtAddress,
-    baseUri
-  }: {
-    sbtAddress: string
-    baseUri: string
-  }): Promise<TransactionReceipt> {
-    this.logger('sbt-js:updateBaseURI')
-    this.logger('sbt-js:updateBaseURI:sbtAddress:', sbtAddress)
-
-    try {
-      const sbtContract = this.fetchSbtContract(sbtAddress)
-      return (await sbtContract.updateBaseURI(baseUri)).wait()
-    } catch (err) {
-      throw new SbtError(SbtErrorCode.UpdateBaseUriError, err)
-    }
-  }
-
   public async sendKlayReward({
     userAddress,
     tokenAmount

--- a/test/sbt.ts
+++ b/test/sbt.ts
@@ -83,20 +83,7 @@ describe('SBT', () => {
     expect(async () => await sbt.getTokenUri({ sbtAddress, tokenId: 100 })).rejects.toThrow()
   })
 
-  it('#5 updateBaseUri should pass', async function () {
-    const newBaseUri = 'http://localhost/'
-    await sbt.updateBaseUri({ sbtAddress, baseUri: newBaseUri })
-    let tokenUri = await sbt.getTokenUri({ sbtAddress, tokenId })
-    logger('sbt-test:updateBaseUri:tokenUri', tokenUri)
-    assert.equal(tokenUri, newBaseUri + tokenId.toString())
-
-    await sbt.updateBaseUri({ sbtAddress, baseUri })
-    tokenUri = await sbt.getTokenUri({ sbtAddress, tokenId })
-    logger('sbt-test:updateBaseUri:tokenUri', tokenUri)
-    assert.equal(tokenUri, baseUri + tokenId.toString())
-  })
-
-  it('#6 sendKlayReward', async function () {
+  it('#5 sendKlayReward', async function () {
     const tokenAmount = '11'
     logger('sbt-test:sendKlayReward:ACCOUNTS.accountAdr1', ACCOUNTS.accountAdr1)
     const txReceipt = await sbt.sendKlayReward({ userAddress: ACCOUNTS.accountAdr1, tokenAmount })


### PR DESCRIPTION
This PR is ready to review. 

Updates: 
- integration to the change on sbt-contract -> https://github.com/Bisonai/sbt-contracts/pull/19
- remove updateBaseURI from test
- `sbt-contract` version increase to 0.5.0  
- bumb up version from 0.4.0 to 0.5.0
