### PR TITLE
add owner of interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bisonai/sbt-js",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Typescript interface to control SBT from @bisonai/sbt-contracts",
   "files": [
     "dist"

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -2,6 +2,7 @@ export enum SbtErrorCode {
   DeploySbtError = 10000,
   MintSbtError,
   GetTokenUriError,
+  OwnerOfError,
   UpdateBaseUriError,
   SendKlayRewardError
 }

--- a/src/sbt.ts
+++ b/src/sbt.ts
@@ -89,6 +89,25 @@ export class SBT {
     }
   }
 
+  public async ownerOf({
+    sbtAddress,
+    tokenId
+  }: {
+    sbtAddress: string
+    tokenId: number
+  }): Promise<TransactionReceipt> {
+    this.logger('sbt-js:ownerOf')
+    this.logger('sbt-js:ownerOf:sbtAddress:', sbtAddress)
+    this.logger('sbt-js:ownerOf:tokenId:', tokenId)
+
+    try {
+      const sbtContract = this.fetchSbtContract(sbtAddress)
+      return await sbtContract.ownerOf(tokenId)
+    } catch (err) {
+      throw new SbtError(SbtErrorCode.OwnerOfError, err)
+    }
+  }
+
   public async sendKlayReward({
     userAddress,
     tokenAmount

--- a/test/sbt.ts
+++ b/test/sbt.ts
@@ -83,7 +83,17 @@ describe('SBT', () => {
     expect(async () => await sbt.getTokenUri({ sbtAddress, tokenId: 100 })).rejects.toThrow()
   })
 
-  it('#5 sendKlayReward', async function () {
+  it('#5 Get ownerOf tokenId', async function () {
+    const ownerOfToken = await sbt.ownerOf({ sbtAddress, tokenId })
+    logger('sbt-test:ownerOf', ownerOfToken)
+    assert.equal(ownerOfToken, ACCOUNTS.accountAdr0)
+  })
+
+  it('#6 Get ownerOf tokenId should fail with invalid ID', async function () {
+    expect(async () => await sbt.ownerOf({ sbtAddress, tokenId: 100 })).rejects.toThrow()
+  })
+
+  it('#7 sendKlayReward', async function () {
     const tokenAmount = '11'
     logger('sbt-test:sendKlayReward:ACCOUNTS.accountAdr1', ACCOUNTS.accountAdr1)
     const txReceipt = await sbt.sendKlayReward({ userAddress: ACCOUNTS.accountAdr1, tokenAmount })

--- a/yarn.lock
+++ b/yarn.lock
@@ -297,10 +297,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bisonai/sbt-contracts@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@bisonai/sbt-contracts/-/sbt-contracts-0.4.0.tgz#ba45e423264aa4230fe0f65fad15b0bdd8b269ad"
-  integrity sha512-fzGB8mHnVBESefyZA1rgZjzDJ5BmxCuN24VoHgwp4K5aQ0NaTLfNNk4HxegXbCMnej1C28yRV6/15bPrsSjImA==
+"@bisonai/sbt-contracts@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@bisonai/sbt-contracts/-/sbt-contracts-0.5.0.tgz#d54a6dce5f8567c13229628189584da81d0624f8"
+  integrity sha512-2+B3I7w21Z70UhQGbfjEcs5aSWz8q8+TblON7Mj0qVXb8GCDK+8QmpCFhe+/PRJz1oUt1ZaIIBpQ6i32bAZPKw==
 
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"


### PR DESCRIPTION
This PR is ready to review and merge. 

Changes:
- Add `ownerOf` interface to be able to check owner of `tokenId`
- Add tests for `ownerOf`
- bump up version from 0.5.0 -> 0.6.0